### PR TITLE
Update CI to use setup-gap@v3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,35 +19,32 @@ concurrency:
 jobs:
   # The CI test job
   test:
-    name: ${{ matrix.gap-branch }}
+    name: ${{ matrix.gap-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        gap-branch:
-          - master
-          - stable-4.16
-          - stable-4.15
-          - stable-4.14
-          - stable-4.13
-          - stable-4.12
-          - stable-4.11
-          - stable-4.10
-          - stable-4.9
+        gap-version:
+          - 'devel'   # current GAP development version from git
+          - 'latest'  # latest GAP release
+          - 'minimal' # oldest GAP release supported by this package
 
     steps:
       - uses: actions/checkout@v6
-      - uses: gap-actions/setup-gap@v2
+      - uses: gap-actions/setup-gap@v3
         with:
-          GAP_PKGS_TO_CLONE: "anupq" # WORKAROUND: currently distributed version fails
-          GAP_PKGS_TO_BUILD: "io profiling anupq"
-          GAPBRANCH: ${{ matrix.gap-branch }}
-      - uses: gap-actions/build-pkg@v1
-      - uses: gap-actions/run-pkg-tests@v3
-      - uses: gap-actions/run-pkg-tests@v3
+          gap-version: ${{ matrix.gap-version }}
+      - uses: gap-actions/install-pkg@v1
         with:
-          only-needed: true
-      - uses: gap-actions/process-coverage@v2
+          packages: "anupq" # WORKAROUND: currently distributed version fails
+      - uses: gap-actions/build-pkg@v3
+        with:
+          extra-pkgs: "io profiling anupq"
+      - uses: gap-actions/run-pkg-tests@v4
+      - uses: gap-actions/run-pkg-tests@v4
+        with:
+          mode: onlyneeded
+      - uses: gap-actions/process-coverage@v3
       - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,11 +35,7 @@ jobs:
         with:
           gap-version: ${{ matrix.gap-version }}
       - uses: gap-actions/install-pkg@v1
-        with:
-          packages: "anupq" # WORKAROUND: currently distributed version fails
       - uses: gap-actions/build-pkg@v3
-        with:
-          extra-pkgs: "io profiling anupq"
       - uses: gap-actions/run-pkg-tests@v4
       - uses: gap-actions/run-pkg-tests@v4
         with:

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -77,7 +77,7 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">=4.10",
+  GAP := ">=4.12",
   NeededOtherPackages := [["Polycyclic", ">=1.0"],
                           ["Autpgrp", ">=1.0"],
                           ["anupq",">=1.0"]],

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -77,7 +77,7 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">=4.4",
+  GAP := ">=4.10",
   NeededOtherPackages := [["Polycyclic", ">=1.0"],
                           ["Autpgrp", ">=1.0"],
                           ["anupq",">=1.0"]],


### PR DESCRIPTION
Update the CI workflow to use current gap-actions releases, migrate legacy inputs, and standardize the GAP version matrix.